### PR TITLE
fix: GitHub Pages の Jekyll が Astro ソースを誤処理しないよう設定

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,12 @@
+# Astro プロジェクトのソースを Jekyll が処理しないようにする
+# （GitHub Pages がブランチ由来の Jekyll ビルドを走らせた場合の保険）
+exclude:
+  - src
+  - node_modules
+  - dist
+  - astro.config.mjs
+  - package.json
+  - package-lock.json
+  - tsconfig.json
+  - .vscode
+  - .github


### PR DESCRIPTION
Jekyll による Invalid YAML front matter エラーを防ぐため、src を除外し .nojekyll を追加。