### PR TITLE
fix: GitHub Actions に Node.js と npm を明示指定

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,9 +16,17 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
       - name: Install, build, and upload your site
         uses: withastro/action@v3
+        with:
+          package-manager: npm
 
   deploy:
     needs: build


### PR DESCRIPTION
withastro/action が lockfile を検出できない問題を防ぐため、setup-node と package-manager を追加。